### PR TITLE
Additional method

### DIFF
--- a/flixel-desktop/src/org/flixel/FlxDesktopApplication.java
+++ b/flixel-desktop/src/org/flixel/FlxDesktopApplication.java
@@ -14,4 +14,9 @@ public class FlxDesktopApplication extends LwjglApplication
 	{
 		this(Game, Width, Height, false);
 	}
+	
+	public FlxDesktopApplicationC(FlxGame Game, String title, int Width, int Height, boolean UseGL2)
+	{
+	    	super((ApplicationListener)Game.stage, title, Width, Height, UseGL2);
+	}
 }


### PR DESCRIPTION
Allows for users to set their own window title rather than using the FlxG.getLibraryName() which is not helpful/useful in most cases.
